### PR TITLE
Add tests and pytest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,26 @@
+# Tests
+
+This directory contains unit tests for the core functionality of the Scholar Slack Bot.
+
+## What is covered
+- **Publication cleaning (`clean_pubs`)** – verifies that old papers, uncited works, and duplicates are filtered out correctly.
+- **Slack message formatting (`make_slack_msg`)** – ensures duplicate articles are deduplicated and that empty publication lists are handled.
+- **Slack channel lookup (`get_channel_id_by_name`)** – mocks the Slack API to confirm that known channels are found and missing channels return `None`.
+- **Message delivery (`send_to_slack`)** – checks that messages are sent to channels when available, fall back to user DMs when needed, and handle invalid recipients.
+
+## Running tests
+Run all tests locally with:
+
+```bash
+pytest
+```
+
+## Automatic testing on commit
+The repository uses a [pre-commit](https://pre-commit.com/) hook to run `pytest` before each commit. Enable it with:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+After installation, `pytest` will run automatically whenever you `git commit`, preventing commits if tests fail.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import sys
+from types import ModuleType
+from pathlib import Path
+
+# Stub external modules not needed for tests
+scholarly_stub = ModuleType("scholarly")
+scholarly_stub.scholarly = object()
+sys.modules.setdefault("scholarly", scholarly_stub)
+
+# Ensure project root is on sys.path for module imports
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_helper_funcs.py
+++ b/tests/test_helper_funcs.py
@@ -1,0 +1,65 @@
+import pytest
+from helper_funcs import clean_pubs
+
+
+def test_clean_pubs_filters_duplicates_and_citations():
+    fetched = [
+        {
+            "bib": {
+                "pub_year": "2023",
+                "title": "Paper A",
+                "author": "Alice",
+                "abstract": "A",
+                "citation": "Journal A",
+            },
+            "num_citations": 5,
+            "pub_url": "http://a",
+        },
+        {
+            "bib": {
+                "pub_year": "2024",
+                "title": "Paper B",
+                "author": "Bob",
+                "abstract": "B",
+                "citation": "Journal B",
+            },
+            "num_citations": 10,
+            "pub_url": "http://b",
+        },
+        {
+            "bib": {
+                "pub_year": "2023",
+                "title": "Paper A",
+                "author": "Alice",
+                "abstract": "A",
+                "citation": "Journal A",
+            },
+            "num_citations": 5,
+            "pub_url": "http://a2",
+        },
+        {
+            "bib": {
+                "pub_year": "2022",
+                "title": "Paper C",
+                "author": "Carol",
+                "abstract": "C",
+                "citation": "Journal C",
+            },
+            "num_citations": 0,
+            "pub_url": "http://c",
+        },
+    ]
+
+    result = clean_pubs(fetched, from_year=2023, exclude_not_cited_papers=True)
+
+    assert result == [
+        {
+            "title": "Paper A",
+            "authors": "Alice",
+            "abstract": "A",
+            "year": "2023",
+            "num_citations": 5,
+            "journal": "Journal A",
+            "pub_url": "http://a",
+        }
+    ]

--- a/tests/test_slack_bot.py
+++ b/tests/test_slack_bot.py
@@ -1,0 +1,115 @@
+from unittest.mock import Mock, patch
+
+from slack_bot import make_slack_msg, get_channel_id_by_name, send_to_slack
+
+
+def test_make_slack_msg_handles_duplicates_and_formats():
+    authors = [("Alice", "A1"), ("Bob", "B1")]
+    articles = [
+        {
+            "title": "Title1",
+            "authors": "Alice",
+            "abstract": "A",
+            "year": "2023",
+            "num_citations": 2,
+            "journal": "Journal1",
+            "pub_url": "url1",
+        },
+        {
+            "title": "Title1",
+            "authors": "Alice",
+            "abstract": "A",
+            "year": "2023",
+            "num_citations": 2,
+            "journal": "Journal1",
+            "pub_url": "url1",
+        },
+    ]
+
+    messages = make_slack_msg(authors, articles)
+
+    assert messages[0].startswith("List of monitored authors")
+    assert messages[1] == "List of publications since my last check:\n"
+    assert len(messages) == 3  # authors message + header + 1 unique article message
+    assert "Title1" in messages[2]
+
+
+def test_make_slack_msg_no_articles():
+    authors = [("Alice", "A1")]
+
+    messages = make_slack_msg(authors, [])
+
+    assert messages[0].startswith("List of monitored authors")
+    assert messages[1] == "No new publications since my last check."
+
+
+@patch("slack_bot.requests.get")
+def test_get_channel_id_by_name_found(mock_get):
+    mock_resp = {
+        "ok": True,
+        "channels": [
+            {"name": "general", "id": "C123"},
+            {"name": "random", "id": "C456"},
+        ],
+        "response_metadata": {},
+    }
+    mock_get.return_value = Mock()
+    mock_get.return_value.json.return_value = mock_resp
+
+    channel_id = get_channel_id_by_name("general", "token")
+
+    assert channel_id == "C123"
+    mock_get.assert_called_once()
+
+
+@patch("slack_bot.requests.get")
+def test_get_channel_id_by_name_not_found(mock_get):
+    mock_resp = {"ok": True, "channels": [], "response_metadata": {}}
+    mock_get.return_value = Mock()
+    mock_get.return_value.json.return_value = mock_resp
+
+    channel_id = get_channel_id_by_name("missing", "token")
+
+    assert channel_id is None
+
+
+@patch("slack_bot._send_message_to_channel")
+@patch("slack_bot.get_channel_id_by_name")
+def test_send_to_slack_channel(mock_get_channel, mock_send):
+    mock_get_channel.return_value = "C123"
+    mock_send.return_value = {"ok": True}
+
+    resp = send_to_slack("general", "hi", "token")
+
+    assert resp == {"ok": True}
+    mock_send.assert_called_once_with("C123", "hi", "token")
+
+
+@patch("slack_bot._send_message_to_channel")
+@patch("slack_bot.open_im_channel")
+@patch("slack_bot.get_user_id_by_name")
+@patch("slack_bot.get_channel_id_by_name")
+def test_send_to_slack_user(mock_get_channel, mock_get_user, mock_open_im, mock_send):
+    mock_get_channel.return_value = None
+    mock_get_user.return_value = "U1"
+    mock_open_im.return_value = "D1"
+    mock_send.return_value = {"ok": True}
+
+    resp = send_to_slack("alice", "hi", "token")
+
+    assert resp == {"ok": True}
+    mock_open_im.assert_called_once_with("U1", "token")
+    mock_send.assert_called_once_with("D1", "hi", "token")
+
+
+@patch("slack_bot._send_message_to_channel")
+@patch("slack_bot.get_user_id_by_name")
+@patch("slack_bot.get_channel_id_by_name")
+def test_send_to_slack_invalid(mock_get_channel, mock_get_user, mock_send):
+    mock_get_channel.return_value = None
+    mock_get_user.return_value = None
+
+    resp = send_to_slack("unknown", "hi", "token")
+
+    assert resp is None
+    mock_send.assert_not_called()


### PR DESCRIPTION
## Summary
- add unit tests for publication cleaning, Slack message formatting, channel lookup, and message sending
- document how to run the test suite and enable automatic execution with pre-commit
- configure pre-commit to run pytest

## Testing
- `pre-commit run --files tests/README.md tests/test_helper_funcs.py tests/test_slack_bot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c00e294ba88324a0b12509e951cf9d