### PR TITLE
Replace custom log levels with standard logging

### DIFF
--- a/fetch_scholar.py
+++ b/fetch_scholar.py
@@ -16,7 +16,8 @@ import time
 from tqdm import tqdm
 
 from helper_funcs import clean_pubs, get_authors_json, convert_json_to_tuple, ensure_output_folder
-from log_config import MIN, STANDARD
+
+logger = logging.getLogger(__name__)
 
 MAX_RETRIES = 3
 DELAYS = [20, 40, 60]
@@ -44,31 +45,30 @@ def fetch_from_json(args, idx=None):
 
     # Retrieve authors' details from the specified JSON path.
     authors_json = get_authors_json(args.authors_path)
-    logging.log(STANDARD, f"Fetched authors' details from {args.authors_path}.")
+    logger.debug(f"Fetched authors' details from {args.authors_path}.")
 
     # Convert the retrieved JSON data into a tuple representation for easier handling.
     authors = convert_json_to_tuple(authors_json)
-    logging.log(STANDARD, "Converted authors' JSON data into tuple representation.")
+    logger.debug("Converted authors' JSON data into tuple representation.")
 
     # Determine the number of authors to process.
     if idx is not None:
         if idx > len(authors):
-            logging.log(
-                STANDARD,
-                f"Requested {idx} authors but only {len(authors)} available. Using all available authors.",
+            logger.debug(
+                f"Requested {idx} authors but only {len(authors)} available. Using all available authors."
             )
             idx = len(authors)
     else:
         idx = len(authors)
 
     if idx == 0:
-        logging.error("No authors listed in the authors.json file.")
+        logger.error("No authors listed in the authors.json file.")
         return
 
     # Fetch publication details for the determined number of authors from the scholarly database.
     articles = fetch_pubs_dictionary(authors[:idx], args)
-    logging.log(MIN, f"Fetched {len(articles)} articles for the provided authors.")
-    logging.log(MIN, "Publications fetched correctly")
+    logger.info(f"Fetched {len(articles)} articles for the provided authors.")
+    logger.info("Publications fetched correctly")
 
     return authors[:idx], articles
 
@@ -86,12 +86,12 @@ def fetch_publication_details(pub):
     Example:
         publication = fetch_publication_details(some_scholarly_dict)
     """
-    # Log fetching details only when level is MIN
-    logging.log(STANDARD, f"Fetching details for publication {pub['bib']['title']}.")
+    # Log fetching details only when logging level allows for debug information
+    logger.debug(f"Fetching details for publication {pub['bib']['title']}.")
     try:
         return scholarly.fill(pub)
     except Exception as e:
-        logging.error(f"Error fetching publication: {e}")
+        logger.error(f"Error fetching publication: {e}")
         return None
 
 
@@ -110,7 +110,7 @@ def fetch_author_details(author_id):
         author = scholarly.fill(author)
         return author["publications"]
     except Exception as e:
-        logging.error(f"Error fetching author details for ID: {author_id}. {e}")
+        logger.error(f"Error fetching author details for ID: {author_id}. {e}")
         raise e
 
 
@@ -127,15 +127,15 @@ def load_cache(author_id, output_folder):
     # Load cached publications if they exist
     cache_path = os.path.join(output_folder, f"{author_id}.json")  # Determine the cache file path
     if os.path.exists(cache_path):
-        logging.log(STANDARD, f"Cache exists for author {author_id}. Loading...")
+        logger.debug(f"Cache exists for author {author_id}. Loading...")
         try:
             with open(cache_path, "r") as f:
                 return json.load(f)
         except Exception as e:
-            logging.warning(f"Error loading cache for author {author_id}. {e}")
+            logger.warning(f"Error loading cache for author {author_id}. {e}")
             return []
     else:
-        logging.log(STANDARD, f"No cache for author {author_id}. Fetching all.")
+        logger.debug(f"No cache for author {author_id}. Fetching all.")
         return []
 
 
@@ -147,7 +147,7 @@ def get_pubs_to_fetch(author_pubs, cached_pubs, from_year, args):
     - list: List of publications to fetch.
     """
     if args.test_fetching:
-        logging.warning(f"--test_fetching flag True. Loading only cached papers < {str(from_year)}")
+        logger.warning(f"--test_fetching flag True. Loading only cached papers < {str(from_year)}")
 
     # Extract titles from cached publications, only titles before from_year if args.test_fetching == True
     cached_titles = (
@@ -163,9 +163,7 @@ def get_pubs_to_fetch(author_pubs, cached_pubs, from_year, args):
     if args.update_cache == True:
         # Do not filter pubs. If this is True, it means we want to update the cache. So we fetch
         # all the author's pubs for the last year
-        logging.log(
-            MIN, "--update_cache flag True. Re-fetching author's pubs and generating new cache."
-        )
+        logger.info("--update_cache flag True. Re-fetching author's pubs and generating new cache.")
         pubs_to_fetch = [
             item
             for item in author_pubs
@@ -203,8 +201,8 @@ def fetch_selected_pubs(pubs_to_fetch):
         try:
             # Use a ThreadPoolExecutor to parallelize the fetching of publications
             with ThreadPoolExecutor() as executor:
-                # Check if logging level is set to MIN. If so, display a progress bar
-                if logging.getLogger().getEffectiveLevel() == MIN and pubs_to_fetch != []:
+                # Check if logging level is set to INFO. If so, display a progress bar
+                if logger.getEffectiveLevel() == logging.INFO and pubs_to_fetch != []:
                     fetched_pubs = list(
                         tqdm(
                             # Execute fetch_publication_details for each item in pubs_to_fetch concurrently
@@ -213,24 +211,24 @@ def fetch_selected_pubs(pubs_to_fetch):
                             desc="Fetching publications",
                         )
                     )
-                elif logging.getLogger().getEffectiveLevel() != MIN and pubs_to_fetch != []:
+                elif logger.getEffectiveLevel() != logging.INFO and pubs_to_fetch != []:
                     # If not using a progress bar, simply map the function across the publications
                     fetched_pubs = list(executor.map(fetch_publication_details, pubs_to_fetch))
                 else:
-                    logging.log(STANDARD, "No new publications. Skipping..")
+                    logger.debug("No new publications. Skipping..")
                     fetched_pubs = []
             # Return the fetched publications
             return fetched_pubs
         except Exception as e:
             # If an exception occurs and it's not the last retry attempt, log a warning and delay
             if retry < MAX_RETRIES - 1:
-                logging.warning(
+                logger.warning(
                     f"Error fetching publications. Retrying in {DELAYS[retry]} seconds. Error: {e}"
                 )
                 time.sleep(DELAYS[retry])  # Delay for a specified amount of time before retrying
             else:
                 # If it's the last retry attempt, log an error and return an empty list
-                logging.error(f"Max retries reached. Exiting fetch process. Error: {e}")
+                logger.error(f"Max retries reached. Exiting fetch process. Error: {e}")
                 return []
 
 
@@ -244,7 +242,7 @@ def save_updated_cache(fetched_pubs, cached_pubs, author_id, output_folder, args
     - output_folder (str): Directory to save the cache.
     """
     cache_path = os.path.join(output_folder, f"{author_id}.json")
-    logging.log(STANDARD, f"Updating cache for author {author_id}.")
+    logger.debug(f"Updating cache for author {author_id}.")
     with open(cache_path, "w") as f:
         combined_pubs = fetched_pubs + cached_pubs if not args.update_cache else fetched_pubs
         json.dump(combined_pubs, f, indent=4)
@@ -331,7 +329,7 @@ def fetch_pubs_dictionary(authors, args, output_dir="./src"):
 
     # Ensure the output directory exists.
     if not os.path.exists(output_folder):
-        logging.log(MIN, f"Creating output folder at {output_folder}.")
+        logger.info(f"Creating output folder at {output_folder}.")
         os.makedirs(output_folder)
 
     # Fetch the publications of the current year.
@@ -339,7 +337,7 @@ def fetch_pubs_dictionary(authors, args, output_dir="./src"):
     total_authors = len(params["authors"])
 
     for i, (author, author_id) in enumerate(params["authors"]):
-        logging.log(MIN, f"Progress: {i+1}/{total_authors} - {author}")
+        logger.info(f"Progress: {i+1}/{total_authors} - {author}")
         author_publications = fetch_publications_by_id(
             author_id, output_folder, args, from_year=params["from_year"]
         )

--- a/helper_funcs.py
+++ b/helper_funcs.py
@@ -10,21 +10,22 @@ import shutil
 import logging
 import json
 from scholarly import scholarly
-from log_config import MIN, STANDARD
+
+logger = logging.getLogger(__name__)
 
 
 def delete_temp_cache(args):
     if os.path.isdir(args.temp_cache_path):
         try:
             shutil.rmtree(args.temp_cache_path)
-            logging.log(STANDARD, "Temporary cache cleared.")
+            logger.debug("Temporary cache cleared.")
         except Exception as e:
-            logging.error(
+            logger.error(
                 f"Failed to delete cache at {args.temp_cache_path}. Please delete the folder manually."
             )
-            logging.error(f"Reason: {str(e)}")
+            logger.error(f"Reason: {str(e)}")
     else:
-        logging.log(STANDARD, f"Temporary cache not found at {args.temp_cache_path}.")
+        logger.debug(f"Temporary cache not found at {args.temp_cache_path}.")
 
 
 def confirm_temp_cache(temp_cache_path="./src/temp_cache", old_cache_path="./src/googleapi_cache"):
@@ -45,18 +46,18 @@ def confirm_temp_cache(temp_cache_path="./src/temp_cache", old_cache_path="./src
 
     # Check if temp_cache_path exists
     if not os.path.exists(temp_cache_path):
-        logging.warning(
+        logger.warning(
             f"Temporary cache path '{temp_cache_path}' does not exist. New articles are NOT saved to cache."
         )
         return
 
     # Check if old_cache_path exists
     if not os.path.exists(old_cache_path):
-        logging.log(MIN, f"Cache path '{old_cache_path}' does not exist. Creating.")
+        logger.info(f"Cache path '{old_cache_path}' does not exist. Creating.")
         os.makedirs(old_cache_path, exist_ok=True)
 
     # Log the beginning of the process
-    logging.log(STANDARD, "Starting to move files from temporary cache to old cache.")
+    logger.debug("Starting to move files from temporary cache to old cache.")
 
     # Iterate over every file in the temporary cache path
     for file_name in os.listdir(temp_cache_path):
@@ -65,11 +66,11 @@ def confirm_temp_cache(temp_cache_path="./src/temp_cache", old_cache_path="./src
 
         # Move file from temporary cache to old cache, overwriting if necessary
         shutil.move(source_path, destination_path)
-        logging.log(STANDARD, f"Moved '{file_name}' from temporary cache to old cache.")
+        logger.debug(f"Moved '{file_name}' from temporary cache to old cache.")
 
     # After moving all files, remove the temporary cache directory
     os.rmdir(temp_cache_path)
-    logging.log(STANDARD, f"Temporary cache path '{temp_cache_path}' has been deleted.")
+    logger.debug(f"Temporary cache path '{temp_cache_path}' has been deleted.")
 
     return
 
@@ -115,7 +116,7 @@ def add_new_author_to_json(authors_path, scholar_id):
     - Exception: If an error occurs while fetching the author using the `scholarly` module.
     """
 
-    logging.log(MIN, f"Adding author ID {scholar_id} to {authors_path}.")
+    logger.info(f"Adding author ID {scholar_id} to {authors_path}.")
     # Get the old authors json
     with open(authors_path, "r") as f:
         old_authors_json = json.load(f)
@@ -124,7 +125,7 @@ def add_new_author_to_json(authors_path, scholar_id):
     try:
         author_fetched = scholarly.search_author_id(scholar_id)
     except Exception as e:
-        print(f"Error encountered: {e}")
+        logger.error(f"Error encountered: {e}")
         raise  # this will raise the caught exception and stop the code
 
     # Extract the name of the author and create a dictionary entry
@@ -138,18 +139,17 @@ def add_new_author_to_json(authors_path, scholar_id):
         old_authors_json.append(author_dict)
     else:
         # Handle the case where the author already exists, e.g., log a message
-        logging.log(
-            MIN,
-            f"Author with ID {scholar_id} already exists in the list and will not be added again.",
+        logger.info(
+            f"Author with ID {scholar_id} already exists in the list and will not be added again."
         )
 
     try:
         # Save the updated list of authors back to the JSON file
         with open(authors_path, "w") as f:
             json.dump(old_authors_json, f, indent=4)
-        logging.log(STANDARD, f"Author {author_name} added to {authors_path}.")
+        logger.debug(f"Author {author_name} added to {authors_path}.")
     except:
-        logging.error(f"There was an error adding {author_name} to {authors_path}.")
+        logger.error(f"There was an error adding {author_name} to {authors_path}.")
 
     return author_dict
 
@@ -255,5 +255,5 @@ def ensure_output_folder(output_folder):
     - Exception: If there's any error during folder creation.
     """
     if not os.path.exists(output_folder):  # Check if directory exists
-        logging.info(f"Output folder '{output_folder}' does not exist. Creating it.")
+        logger.info(f"Output folder '{output_folder}' does not exist. Creating it.")
         os.makedirs(output_folder)  # Create directory

--- a/log_config.py
+++ b/log_config.py
@@ -1,17 +1,36 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Created on Sat Oct  7 17:42:13 2023
-
-@author: costantino_ai
-"""
+"""Logging configuration for scholar-slack-bot."""
 
 import logging
+import logging.config
 
-# Define custom logging levels
-MIN = 35
-STANDARD = 25
 
-# Add custom logging levels
-logging.addLevelName(MIN, "MIN")
-logging.addLevelName(STANDARD, "STANDARD")
+def setup_logging(verbose: bool = False) -> None:
+    """Configure root logger using ``logging.config.dictConfig``.
+
+    Parameters
+    ----------
+    verbose: bool
+        When ``True`` set the logging level to ``DEBUG``; otherwise ``INFO``.
+    """
+    level = "DEBUG" if verbose else "INFO"
+    config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            }
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+                "level": "DEBUG",
+            }
+        },
+        "root": {"handlers": ["console"], "level": level},
+    }
+    logging.config.dictConfig(config)
+

--- a/main.py
+++ b/main.py
@@ -21,10 +21,9 @@ from streams_funcs import (
     add_scholar_and_fetch,
     regular_fetch_and_message,
 )
-from log_config import MIN, STANDARD
+from log_config import setup_logging
 
-# Configure logging
-logging.basicConfig(level=STANDARD)
+logger = logging.getLogger(__name__)
 
 
 def get_args():
@@ -82,7 +81,7 @@ def initialize_args():
     if len(sys.argv) > 1:
         # Parse command-line arguments
         parser, args = get_args()
-        logging.log(MIN, "Parsed command-line arguments.")
+        logger.info("Parsed command-line arguments.")
     else:
         # Default configurations for execution in IDE
         class IDEArgs:
@@ -103,17 +102,16 @@ def initialize_args():
             "--add_scholar_id and --update_cache cannot be used together or with --test_fetching, --test_message"
         )
 
-    # Reconfigure logging based on DEBUG_FLAG's value
+    # Configure logging based on verbosity
+    setup_logging(verbose=args.verbose)
     if args.verbose:
-        logging.basicConfig(level=STANDARD)
-        logging.log(STANDARD, "STANDARD log mode activated.")
+        logger.debug("Verbose log mode activated.")
     else:
-        logging.basicConfig(level=MIN)
-        logging.log(MIN, "MIN log mode activated.")
+        logger.info("Minimal log mode activated.")
 
     # Display the arguments being used
     for arg, value in vars(args).items():
-        logging.log(STANDARD, f"Argument {arg} = {value}")
+        logger.debug(f"Argument {arg} = {value}")
 
     return args
 
@@ -138,7 +136,8 @@ def main():
     Note: If running from an IDE, configurations are hardcoded.
 
     """
-    logging.log(MIN, "Initializing...")
+    setup_logging()
+    logger.info("Initializing...")
 
     # Get the arguments
     args = initialize_args()
@@ -157,7 +156,7 @@ def main():
     # Assign Slack API token and channel name from the config
     token = slack_config["api_token"]
     ch_name = slack_config["channel_name"]
-    logging.log(MIN, f"Target Slack channel: {ch_name}.")
+    logger.info(f"Target Slack channel: {ch_name}.")
 
     # Scenario 1: Test message. No fetching or cache update.
     if args.test_message and not args.test_fetching:
@@ -186,7 +185,7 @@ def main():
     # Attempt to clean the new temporary cache
     delete_temp_cache(args)
 
-    logging.log(MIN, "Done.")
+    logger.info("Done.")
     return args
 
 

--- a/slack_bot.py
+++ b/slack_bot.py
@@ -9,7 +9,7 @@ import requests
 import configparser
 import logging
 
-from log_config import MIN, STANDARD
+logger = logging.getLogger(__name__)
 
 
 def send_test_msg(token, ch_name):
@@ -46,7 +46,7 @@ def send_test_msg(token, ch_name):
 
     # Check if the message was sent successfully and log the outcome.
     if response_json["ok"]:
-        logging.log(MIN, f"Test message successfully sent to #{ch_name}")
+        logger.info(f"Test message successfully sent to #{ch_name}")
 
 
 def make_slack_msg(authors: list, articles: list) -> list:
@@ -106,7 +106,7 @@ def get_slack_config(slack_config_path="./src/slack.config"):
         "channel_name": config.get("slack", "channel_name"),
     }
 
-    logging.log(STANDARD, f"Fetched Slack configuration from {slack_config_path}.")
+    logger.debug(f"Fetched Slack configuration from {slack_config_path}.")
     return slack_config
 
 def format_pub_message(pub):
@@ -158,7 +158,7 @@ def format_pub_message(pub):
 
     # Joining the details list into a single string separated by newline characters
     message = "\n".join(details)
-    print(message)  # Printing the formatted message
+    logger.debug(message)
 
     return message  # Returning the formatted message
 
@@ -204,7 +204,7 @@ def get_channel_id_by_name(channel_name, token):
     while True:
         response = requests.get(url, headers=headers, params=params).json()
         if not response["ok"]:
-            logging.warning(f"Failed to list channels: {response['error']}")
+            logger.warning(f"Failed to list channels: {response['error']}")
             return None
 
         for channel in response["channels"]:
@@ -234,7 +234,7 @@ def get_user_id_by_name(user_name, token):
     while True:
         response = requests.get(url, headers=headers, params=params).json()
         if not response["ok"]:
-            logging.warning(f"Failed to list users: {response['error']}")
+            logger.warning(f"Failed to list users: {response['error']}")
             return None
 
         for member in response["members"]:
@@ -267,7 +267,7 @@ def open_im_channel(user_id, token):
 
     response = requests.post(url, headers=headers, json=data).json()
     if not response["ok"]:
-        logging.warning(f"Error opening DM for user {user_id}: {response}")
+        logger.warning(f"Error opening DM for user {user_id}: {response}")
         return None
 
     return response["channel"]["id"]
@@ -298,7 +298,7 @@ def send_to_slack(channel_or_user_name, message, token):
         return response
 
     # 3. If neither was found, log an error
-    logging.error(
+    logger.error(
         f"Error: '{channel_or_user_name}' is not a valid channel or user in this workspace."
     )
 
@@ -315,11 +315,11 @@ def _send_message_to_channel(channel_id, message, token):
     response = requests.post(url, headers=headers, json=data).json()
 
     if not response.get("ok"):
-        logging.warning(
+        logger.warning(
             f"Sending message to #{channel_id} failed. Error: {response.get('error')}. "
             f"Message:\n{message}"
         )
     else:
-        logging.log(STANDARD, f"Message successfully sent to #{channel_id}.")
+        logger.debug(f"Message successfully sent to #{channel_id}.")
 
     return response

--- a/streams_funcs.py
+++ b/streams_funcs.py
@@ -8,10 +8,11 @@ Created on Fri Oct 20 17:02:03 2023
 import os
 import shutil
 import logging
-from log_config import MIN, STANDARD
 from helper_funcs import confirm_temp_cache, add_new_author_to_json, convert_json_to_tuple
 from fetch_scholar import fetch_from_json, fetch_pubs_dictionary
 from slack_bot import make_slack_msg, send_to_slack
+
+logger = logging.getLogger(__name__)
 
 
 def update_cache_only(args):
@@ -22,7 +23,7 @@ def update_cache_only(args):
         cache_path (str): Path to the actual cache.
     """
     confirm_temp_cache(args.temp_cache_path, args.cache_path)
-    logging.log(MIN, "Fetched pubs successfully moved to cache and temporary cache cleared.")
+    logger.info("Fetched pubs successfully moved to cache and temporary cache cleared.")
 
 
 def test_fetch_and_message(args, ch_name, token):
@@ -51,7 +52,7 @@ def test_fetch_and_message(args, ch_name, token):
 
     # Convert fetched details into formatted messages suitable for Slack.
     formatted_messages = make_slack_msg(authors, articles)
-    logging.log(MIN, f"Formatted test messages for {len(authors)} authors.")
+    logger.info(f"Formatted test messages for {len(authors)} authors.")
 
     test_header = "!!! This is a test message !!!"
     success = True  # To track if all messages are sent successfully.
@@ -66,13 +67,13 @@ def test_fetch_and_message(args, ch_name, token):
             success = False
             e = response_json["error"]
             # It might be useful to log failures as they happen.
-            logging.warning(f"Failed to send a test message due to: {e}")
+            logger.warning(f"Failed to send a test message due to: {e}")
 
     # Log overall success or failure.
     if success:
-        logging.log(MIN, "All test messages sent successfully.")
+        logger.info("All test messages sent successfully.")
     else:
-        logging.error("There was a problem sending one or more test messages.")
+        logger.error("There was a problem sending one or more test messages.")
 
 
 def regular_fetch_and_message(args, ch_name, token):
@@ -98,7 +99,7 @@ def regular_fetch_and_message(args, ch_name, token):
 
     # Convert fetched details into messages suitable for Slack.
     formatted_messages = make_slack_msg(authors, articles)
-    logging.log(MIN, f"Formatted messages for {len(authors)} authors.")
+    logger.info(f"Formatted messages for {len(authors)} authors.")
 
     # Initialize a success flag to track message sending process.
     success = True
@@ -112,17 +113,15 @@ def regular_fetch_and_message(args, ch_name, token):
         if not response_json["ok"]:
             success = False
             error_message = response_json.get("error", "Unknown error")
-            logging.warning(f"Failed to send a message due to: {error_message}")
+            logger.warning(f"Failed to send a message due to: {error_message}")
 
     # Handle post-message actions based on the success flag.
     if success:
         confirm_temp_cache(args.temp_cache_path, args.cache_path)
-        logging.log(
-            MIN, "Fetched publications successfully moved to cache. Temporary cache cleared."
-        )
+        logger.info("Fetched publications successfully moved to cache. Temporary cache cleared.")
     else:
         # Clear the temporary cache due to the failure in sending messages.
-        logging.error(
+        logger.error(
             f"Problem sending one or more messages to Slack. Cache was not updated. Error: {error_message}"
         )
 
@@ -146,18 +145,17 @@ def refetch_and_update(args):
     if os.path.isdir(args.temp_cache_path):
         try:
             shutil.rmtree(args.cache_path)
-            logging.log(STANDARD, f"Deleted old cache at {args.cache_path}")
+            logger.debug(f"Deleted old cache at {args.cache_path}")
         except Exception as e:  # Handle specific exception to avoid broad except.
-            logging.error(f"Failed to delete old cache at {args.cache_path}. Reason: {str(e)}")
+            logger.error(f"Failed to delete old cache at {args.cache_path}. Reason: {str(e)}")
 
     # Refetch all the author and publication details.
     _ = fetch_from_json(args)
 
     # Update the cache with newly fetched data.
     update_cache_only(args)
-    logging.log(
-        MIN,
-        "Re-fetched all publications. Data successfully moved to cache and temporary cache cleared.",
+    logger.info(
+        "Re-fetched all publications. Data successfully moved to cache and temporary cache cleared."
     )
 
 
@@ -181,16 +179,15 @@ def add_scholar_and_fetch(args):
     json_filepath = os.path.join(args.cache_path, json_filename)
 
     if os.path.exists(json_filepath):
-        logging.log(
-            MIN,
-            f"Author with scholar ID {args.add_scholar_id} is already in the authors JSON file. Fetching is skipped.",
+        logger.info(
+            f"Author with scholar ID {args.add_scholar_id} is already in the authors JSON file. Fetching is skipped."
         )
         return
 
     # Add the new author's data to the authors' JSON file and get their dictionary representation.
     author_dict = add_new_author_to_json(args.authors_path, args.add_scholar_id)
-    logging.log(
-        STANDARD, f"Added new author with scholar ID {args.add_scholar_id} to authors' JSON."
+    logger.debug(
+        f"Added new author with scholar ID {args.add_scholar_id} to authors' JSON."
     )
 
     # Create a single-entry list with the new author's data for subsequent processing.
@@ -198,12 +195,12 @@ def add_scholar_and_fetch(args):
 
     # Convert the retrieved JSON data of the new author into a tuple representation for easier handling.
     authors = convert_json_to_tuple(authors_json)
-    logging.log(STANDARD, "Converted new author's JSON data into tuple representation.")
+    logger.debug("Converted new author's JSON data into tuple representation.")
 
     # Fetch publication details for the new author from the scholarly database.
     articles = fetch_pubs_dictionary(authors, args)
-    logging.log(MIN, f"Fetched {len(articles)} articles for the new author.")
+    logger.info(f"Fetched {len(articles)} articles for the new author.")
 
     # Update the cache with the newly fetched data for the new author.
     update_cache_only(args)
-    logging.log(MIN, "Added author to JSON. Cache successfully updated with new author's data.")
+    logger.info("Added author to JSON. Cache successfully updated with new author's data.")


### PR DESCRIPTION
## Summary
- drop custom MIN/STANDARD logging levels and use built-in INFO/DEBUG
- add centralized `setup_logging` using `logging.config.dictConfig`
- ensure each module uses `logger = logging.getLogger(__name__)` and replace `print` in `format_pub_message`

## Testing
- `python -m py_compile log_config.py main.py helper_funcs.py fetch_scholar.py streams_funcs.py slack_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c00e0d375c8324a8789d4e48e343dd